### PR TITLE
Allow document duplication by removing unique constraint on checksum

### DIFF
--- a/modifications/allow-duplication.plan.md
+++ b/modifications/allow-duplication.plan.md
@@ -1,0 +1,53 @@
+<!-- 59b460f2-02da-4893-9967-ad4f037ce2f2 d0ad845c-b9f2-4c16-baeb-173896f9c5bd -->
+# Allow duplicate document uploads (global)
+
+## Changes
+
+- Backend: Make duplicate preflight a no-op so ingestion doesn’t block.
+  - Update `src/documents/consumer.py` `ConsumerPreflightPlugin.pre_check_duplicate` to return without failing/log only.
+  - Keep call sites intact; method will no-op.
+- Data model: Allow non-unique checksums while preserving query performance.
+  - Edit `src/documents/models.py` `Document.checksum` to remove `unique=True` and add `db_index=True`.
+  - Create a Django migration to drop the unique index and add a non-unique index.
+
+## Key snippets (for context)
+
+- Current duplicate check that fails ingestion:
+```787:809:src/documents/consumer.py
+existing_doc = Document.global_objects.filter(
+    Q(checksum=checksum) | Q(archive_checksum=checksum),
+)
+if existing_doc.exists():
+    ...
+    self._fail(msg, log_msg)
+```
+
+- Current unique checksum definition:
+```219:225:src/documents/models.py
+checksum = models.CharField(
+    max_length=32,
+    editable=False,
+    unique=True,
+)
+```
+
+
+## Migration
+
+- Create a new migration in `src/documents/migrations/` that:
+  - Alters `documents.Document.checksum` to `unique=False, db_index=True`.
+  - Depends on the latest migration number (sequential as per repo).
+
+## Validation
+
+- Reset dev DB or run migrations forward.
+- Upload the same file twice via API `POST /api/documents/post_document/` and verify both succeed.
+- Optional: filter by `?checksum__iexact=...` still works (now returns multiple rows).
+
+### To-dos
+
+- [ ] No-op duplicate preflight in consumer.py to not block ingestion
+- [ ] Remove unique and add db_index to Document.checksum in models.py
+- [ ] Create migration to drop unique index and add non-unique index
+- [ ] Run migrations locally and verify schema
+- [ ] Upload same file twice via API and confirm success

--- a/modifications/allow-duplocation.summary.md
+++ b/modifications/allow-duplocation.summary.md
@@ -1,0 +1,98 @@
+# Allow Duplicate Document Uploads - Implementation Summary
+
+## Overview
+Paperless-ngx now allows adding the same document multiple times. Previously, the system blocked duplicate documents by checking the MD5 checksum of the original file against existing documents.
+
+## Changes Made
+
+### 1. Backend - Consumer Preflight (`src/documents/consumer.py`)
+**File**: `/src/documents/consumer.py` (lines 787-792)
+
+Changed the `ConsumerPreflightPlugin.pre_check_duplicate()` method from a validation check to a no-op:
+- **Before**: Rejected documents if checksum matched existing document
+- **After**: Method now passes without checking, allowing duplicates through
+
+```python
+def pre_check_duplicate(self):
+    """
+    Duplicate documents are now allowed.
+    This method is kept for backwards compatibility but performs no checks.
+    """
+    pass
+```
+
+### 2. Data Model - Document.checksum (`src/documents/models.py`)
+**File**: `/src/documents/models.py` (lines 219-226)
+
+Modified the `checksum` field to allow non-unique values:
+- **Changed**: `unique=True` → `unique=False`
+- **Added**: `db_index=True` for query performance
+
+```python
+checksum = models.CharField(
+    _("checksum"),
+    max_length=32,
+    editable=False,
+    unique=False,        # Now allows duplicates
+    db_index=True,       # Keep queries fast
+    help_text=_("The checksum of the original document."),
+)
+```
+
+### 3. Database Migration (`src/documents/migrations/1077_alter_document_checksum.py`)
+
+Created migration #1077 to:
+- Drop the unique constraint on `Document.checksum`
+- Add a non-unique index for query performance
+
+The migration properly depends on the previous migration (1076) to ensure sequential ordering.
+
+### 4. Tests Updated (`src/documents/tests/test_consumer.py`)
+
+Updated two tests that previously expected duplicate rejection:
+
+**`test_delete_duplicate()` (lines 728-761)**
+- Now verifies that two documents with identical checksums can be created
+- Confirms they have different primary keys but same checksum
+
+**`test_no_delete_duplicate()` (lines 763-796)**
+- Updated to verify duplicate consumption succeeds
+- Validates the behavior mirrors `test_delete_duplicate`
+
+## Behavior Changes
+
+### Before
+- First document upload: ✓ Success
+- Second upload of same file: ✗ Rejected with "document_already_exists" error
+- Setting `CONSUMER_DELETE_DUPLICATES=True` would delete the duplicate file
+- Setting `CONSUMER_DELETE_DUPLICATES=False` would keep the file but fail consumption
+
+### After
+- First document upload: ✓ Success
+- Second upload of same file: ✓ Success (creates new document)
+- Both documents have identical checksums
+- Each document receives a unique ID and filename
+- `CONSUMER_DELETE_DUPLICATES` setting is now ignored (always allows duplicates)
+
+## API Impact
+
+The API endpoint `/api/documents/post_document/` now:
+- Accepts multiple uploads of identical files
+- Each upload creates a new document with a unique ID
+- Checksum queries (e.g., `?checksum__iexact=ABC123`) now return multiple results if duplicates exist
+
+## Database Impact
+
+The migration will:
+1. Remove the unique constraint on `documents_document.checksum`
+2. Add a non-unique index on `documents_document.checksum` for query performance
+
+This is backward compatible - existing data is unaffected.
+
+## Technical Notes
+
+- Checksum comparison uses MD5 hash of the original file
+- Archive files (`archive_checksum`) are separate and not affected
+- The `pre_check_duplicate()` method remains in place for backward compatibility but performs no action
+- File naming is still unique per document, preventing file system clashes
+

--- a/src/documents/consumer.py
+++ b/src/documents/consumer.py
@@ -786,27 +786,10 @@ class ConsumerPreflightPlugin(
 
     def pre_check_duplicate(self):
         """
-        Using the MD5 of the file, check this exact file doesn't already exist
+        Duplicate documents are now allowed.
+        This method is kept for backwards compatibility but performs no checks.
         """
-        with Path(self.input_doc.original_file).open("rb") as f:
-            checksum = hashlib.md5(f.read()).hexdigest()
-        existing_doc = Document.global_objects.filter(
-            Q(checksum=checksum) | Q(archive_checksum=checksum),
-        )
-        if existing_doc.exists():
-            msg = ConsumerStatusShortMessage.DOCUMENT_ALREADY_EXISTS
-            log_msg = f"Not consuming {self.filename}: It is a duplicate of {existing_doc.get().title} (#{existing_doc.get().pk})."
-
-            if existing_doc.first().deleted_at is not None:
-                msg = ConsumerStatusShortMessage.DOCUMENT_ALREADY_EXISTS_IN_TRASH
-                log_msg += " Note: existing document is in the trash."
-
-            if settings.CONSUMER_DELETE_DUPLICATES:
-                Path(self.input_doc.original_file).unlink()
-            self._fail(
-                msg,
-                log_msg,
-            )
+        pass
 
     def pre_check_directories(self):
         """

--- a/src/documents/migrations/1077_alter_document_checksum.py
+++ b/src/documents/migrations/1077_alter_document_checksum.py
@@ -1,0 +1,26 @@
+# Generated migration to allow duplicate documents by removing unique constraint on checksum
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("documents", "1076_remove_customfieldinstance_documents_customfieldinstance_unique_document_field_and_more"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="document",
+            name="checksum",
+            field=models.CharField(
+                db_index=True,
+                editable=False,
+                help_text="The checksum of the original document.",
+                max_length=32,
+                unique=False,
+                verbose_name="checksum",
+            ),
+        ),
+    ]
+

--- a/src/documents/models.py
+++ b/src/documents/models.py
@@ -220,7 +220,8 @@ class Document(SoftDeleteModel, ModelWithOwner):
         _("checksum"),
         max_length=32,
         editable=False,
-        unique=True,
+        unique=False,
+        db_index=True,
         help_text=_("The checksum of the original document."),
     )
 

--- a/src/documents/tests/test_consumer.py
+++ b/src/documents/tests/test_consumer.py
@@ -727,56 +727,73 @@ class TestConsumer(
 
     @override_settings(CONSUMER_DELETE_DUPLICATES=True)
     def test_delete_duplicate(self):
+        """
+        Test that duplicate documents are now allowed to be consumed.
+        The CONSUMER_DELETE_DUPLICATES setting is now ignored since duplicates are always allowed.
+        """
         dst = self.get_test_file()
         self.assertIsFile(dst)
 
         with self.get_consumer(dst) as consumer:
             consumer.run()
 
-            document = Document.objects.first()
+            document1 = Document.objects.first()
 
         self._assert_first_last_send_progress()
 
         self.assertIsNotFile(dst)
-        self.assertIsNotNone(document)
+        self.assertIsNotNone(document1)
 
         dst = self.get_test_file()
         self.assertIsFile(dst)
 
-        with self.assertRaises(ConsumerError):
-            with self.get_consumer(dst) as consumer:
-                consumer.run()
+        # Duplicates are now allowed, so this should succeed
+        with self.get_consumer(dst) as consumer:
+            consumer.run()
+
+            document2 = Document.objects.filter().order_by("-pk").first()
 
         self.assertIsNotFile(dst)
-        self._assert_first_last_send_progress(last_status="FAILED")
+        self._assert_first_last_send_progress()
+        self.assertIsNotNone(document2)
+        # Verify we have two documents with the same checksum
+        self.assertEqual(document1.checksum, document2.checksum)
+        self.assertNotEqual(document1.pk, document2.pk)
 
     @override_settings(CONSUMER_DELETE_DUPLICATES=False)
     def test_no_delete_duplicate(self):
+        """
+        Test that duplicate documents are now allowed to be consumed.
+        The CONSUMER_DELETE_DUPLICATES setting is now ignored since duplicates are always allowed.
+        """
         dst = self.get_test_file()
         self.assertIsFile(dst)
 
         with self.get_consumer(dst) as consumer:
             consumer.run()
 
-            document = Document.objects.first()
+            document1 = Document.objects.first()
 
         self._assert_first_last_send_progress()
 
         self.assertIsNotFile(dst)
-        self.assertIsNotNone(document)
+        self.assertIsNotNone(document1)
 
         dst = self.get_test_file()
         self.assertIsFile(dst)
 
-        with self.assertRaisesRegex(
-            ConsumerError,
-            r"sample\.pdf: Not consuming sample\.pdf: It is a duplicate of sample \(#\d+\)",
-        ):
-            with self.get_consumer(dst) as consumer:
-                consumer.run()
+        # Duplicates are now allowed, so this should succeed
+        with self.get_consumer(dst) as consumer:
+            consumer.run()
 
-        self.assertIsFile(dst)
-        self._assert_first_last_send_progress(last_status="FAILED")
+            document2 = Document.objects.filter().order_by("-pk").first()
+
+        self.assertIsNotFile(dst)
+        self._assert_first_last_send_progress()
+        self.assertIsNotNone(document2)
+        # Verify we have two documents with the same checksum
+        self.assertEqual(document1.checksum, document2.checksum)
+        self.assertNotEqual(document1.pk, document2.pk)
 
     @override_settings(FILENAME_FORMAT="{title}")
     @mock.patch("documents.parsers.document_consumer_declaration.send")


### PR DESCRIPTION
# Allow Duplicate Document Uploads - Implementation Summary

## Overview
Paperless-ngx now allows adding the same document multiple times. Previously, the system blocked duplicate documents by checking the MD5 checksum of the original file against existing documents.

## Changes Made

### 1. Backend - Consumer Preflight (`src/documents/consumer.py`)
**File**: `/src/documents/consumer.py` (lines 787-792)

Changed the `ConsumerPreflightPlugin.pre_check_duplicate()` method from a validation check to a no-op:
- **Before**: Rejected documents if checksum matched existing document
- **After**: Method now passes without checking, allowing duplicates through

```python
def pre_check_duplicate(self):
    """
    Duplicate documents are now allowed.
    This method is kept for backwards compatibility but performs no checks.
    """
    pass
```

### 2. Data Model - Document.checksum (`src/documents/models.py`)
**File**: `/src/documents/models.py` (lines 219-226)

Modified the `checksum` field to allow non-unique values:
- **Changed**: `unique=True` → `unique=False`
- **Added**: `db_index=True` for query performance

```python
checksum = models.CharField(
    _("checksum"),
    max_length=32,
    editable=False,
    unique=False,        # Now allows duplicates
    db_index=True,       # Keep queries fast
    help_text=_("The checksum of the original document."),
)
```

### 3. Database Migration (`src/documents/migrations/1077_alter_document_checksum.py`)

Created migration #1077 to:
- Drop the unique constraint on `Document.checksum`
- Add a non-unique index for query performance

The migration properly depends on the previous migration (1076) to ensure sequential ordering.

### 4. Tests Updated (`src/documents/tests/test_consumer.py`)

Updated two tests that previously expected duplicate rejection:

**`test_delete_duplicate()` (lines 728-761)**
- Now verifies that two documents with identical checksums can be created
- Confirms they have different primary keys but same checksum

**`test_no_delete_duplicate()` (lines 763-796)**
- Updated to verify duplicate consumption succeeds
- Validates the behavior mirrors `test_delete_duplicate`

## Behavior Changes

### Before
- First document upload: ✓ Success
- Second upload of same file: ✗ Rejected with "document_already_exists" error
- Setting `CONSUMER_DELETE_DUPLICATES=True` would delete the duplicate file
- Setting `CONSUMER_DELETE_DUPLICATES=False` would keep the file but fail consumption

### After
- First document upload: ✓ Success
- Second upload of same file: ✓ Success (creates new document)
- Both documents have identical checksums
- Each document receives a unique ID and filename
- `CONSUMER_DELETE_DUPLICATES` setting is now ignored (always allows duplicates)

## API Impact

The API endpoint `/api/documents/post_document/` now:
- Accepts multiple uploads of identical files
- Each upload creates a new document with a unique ID
- Checksum queries (e.g., `?checksum__iexact=ABC123`) now return multiple results if duplicates exist

## Database Impact

The migration will:
1. Remove the unique constraint on `documents_document.checksum`
2. Add a non-unique index on `documents_document.checksum` for query performance

This is backward compatible - existing data is unaffected.

## Technical Notes

- Checksum comparison uses MD5 hash of the original file
- Archive files (`archive_checksum`) are separate and not affected
- The `pre_check_duplicate()` method remains in place for backward compatibility but performs no action
- File naming is still unique per document, preventing file system clashes

